### PR TITLE
Allow to pass compiler options through loader query

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 var _ = require('lodash');
+var loaderUtils = require("loader-utils");
 
 module.exports = function (source) {
   this.cacheable && this.cacheable();
-  var template = _.template(source);
+  var options = loaderUtils.parseQuery(this.query);
+  var template = _.template(source, options);
   return 'module.exports = ' + template;
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/okonet/ejs-loader",
   "dependencies": {
-    "lodash": "^2.4.1"
+    "lodash": "^3.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/okonet/ejs-loader",
   "dependencies": {
-    "lodash": "^3.6.0"
+    "lodash": "^3.6.0",
+    "loader-utils": "^0.2.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "keywords": [
     "ejs",
-    "underscrore",
+    "underscore",
     "lodash",
     "_",
     "webpack",


### PR DESCRIPTION
Webpack config:
```
module: {
    loaders: [{
            test: /\.ejs$/,
            loader: 'ejs-loader?variable=data'
    }]
}
```
Loader behavior:
```
... = _.template(source, {variable: 'data'});
```