### PR TITLE
allow for passing in template settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,22 +30,52 @@ plugins: [
 ]
 ```
 
-### Compiler options
-Query parameters allows to pass options for template compiller.
+### Options
+[Underscore](http://underscorejs.org/#template)/[Lodash](https://lodash.com/docs#template) options can be passed in using the querystring or adding an ```esjLoader``` options block to your configuration.
 
-Config example:
+Config example using a querystring:
 ``` js
 module.exports = {
   module: {
     loaders: [
-      { test: /\.ejs$/, loader: "ejs-loader?variable=data" },
+      { test: /\.ejs$/, loader: 'ejs-loader?variable=data' },
     ]
   }
 };
 ```
 is equivalent to
 ``` js
-var template = _.template('<%= template %>', {variable: 'data'}); 
+var template = _.template('<%= template %>', { variable : 'data' });
+```
+
+``` js
+module.exports = {
+  module: {
+    loaders: [
+      { test: /\.ejs$/, loader: 'ejs-loader', query: { variable: 'data', interpolate : '\\{\\{(.+?)\\}\\}', evaluate : '\\[\\[(.+?)\\]\\]' } },
+    ]
+  }
+};
+```
+is equivalent to
+``` js
+var template = _.template('<%= template %>', { variable: 'data', interpolate : '\\{\\{(.+?)\\}\\}', evaluate : '\\[\\[(.+?)\\]\\]' });
+```
+
+Config example using the ```ejsLoader``` config block:
+``` js
+module.exports = {
+  module: {
+    loaders: [
+      { test: /\.ejs$/, loader: 'ejs-loader',
+    ]
+  },
+  ejsLoader : {
+    variable    : 'data',
+    interpolate : /\{\{(.+?)\}\}/g,
+    evaluate    : /\[\[(.+?)\]\]/g
+  }
+};
 ```
 
 ## Release History

--- a/index.js
+++ b/index.js
@@ -1,9 +1,17 @@
 var _ = require('lodash');
-var loaderUtils = require("loader-utils");
+var loaderUtils = require('loader-utils');
 
-module.exports = function (source) {
+module.exports = function(source) {
   this.cacheable && this.cacheable();
   var options = loaderUtils.parseQuery(this.query);
+
+  ['escape', 'interpolate', 'evaluate'].forEach(function(templateSetting) {
+    var setting = options[templateSetting];
+    if (_.isString(setting)) {
+      options[templateSetting] = new RegExp(setting, 'g');
+    }
+  });
+
   var template = _.template(source, options);
   return 'module.exports = ' + template;
 };

--- a/index.js
+++ b/index.js
@@ -3,15 +3,16 @@ var loaderUtils = require('loader-utils');
 
 module.exports = function(source) {
   this.cacheable && this.cacheable();
-  var options = loaderUtils.parseQuery(this.query);
+  var query = loaderUtils.parseQuery(this.query);
+  var options = this.options.ejsLoader || {};
 
   ['escape', 'interpolate', 'evaluate'].forEach(function(templateSetting) {
-    var setting = options[templateSetting];
+    var setting = query[templateSetting];
     if (_.isString(setting)) {
-      options[templateSetting] = new RegExp(setting, 'g');
+      query[templateSetting] = new RegExp(setting, 'g');
     }
   });
 
-  var template = _.template(source, options);
+  var template = _.template(source, _.extend({}, query, options));
   return 'module.exports = ' + template;
 };


### PR DESCRIPTION
This allows for template settings to be passed through the query. It takes the strings, creates new regexs and adds them to the options to be passed to ```_.template```.

Example:

```javascript
{ 
  test : /\.jst$/,
  exclude : /node_modules/,
  loader : 'ejs-loader',
  query : { interpolate : '\\{\\{(.+?)\\}\\}', evaluate : '\\[\\[(.+?)\\]\\]' }
}
```