### PR TITLE
fix: update for webpack 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,17 @@
 var _ = require('lodash');
 var loaderUtils = require('loader-utils');
 
+function getOptions(context) {
+  if (context.options && context.options.ejsLoader) {
+    return context.options.ejsLoader;
+  }
+  return {};
+}
+
 module.exports = function(source) {
   this.cacheable && this.cacheable();
   var query = loaderUtils.parseQuery(this.query);
-  var options = this.options ? this.options.ejsLoader || {} : {};
+  var options = getOptions(this);
 
   ['escape', 'interpolate', 'evaluate'].forEach(function(templateSetting) {
     var setting = query[templateSetting];

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var loaderUtils = require('loader-utils');
 module.exports = function(source) {
   this.cacheable && this.cacheable();
   var query = loaderUtils.parseQuery(this.query);
-  var options = this.options.ejsLoader || {};
+  var options = this.options ? this.options.ejsLoader || {} : {};
 
   ['escape', 'interpolate', 'evaluate'].forEach(function(templateSetting) {
     var setting = query[templateSetting];


### PR DESCRIPTION
this.options is not available in webpack4 so we check and return
an empty object instead.

Closes #25 